### PR TITLE
Housekeeping

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -7,6 +7,10 @@ class Enigma
     @charset = ("a".."z").to_a << " "
   end
 
+  def generate_today_date
+    Date.today.strftime("%d%m%y")
+  end
+
   def generate_key
     rand(99999).to_s.rjust(5, "0")
   end
@@ -45,8 +49,8 @@ class Enigma
     mutated_string
   end
 
-  def encrypt(message, key = generate_key, date = Date.today.strftime("%d%m%y"))
-    {encryption: mutate_string(message.downcase, key, date, +1),
+  def encrypt(plaintext, key = generate_key, date = generate_today_date)
+    {encryption: mutate_string(plaintext.downcase, key, date, +1),
      key: key,
      date: date}
   end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -51,8 +51,8 @@ class Enigma
      date: date}
   end
 
-  def decrypt(cipher, key, date = Date.today.strftime("%d%m%y"))
-    {decryption: mutate_string(cipher, key, date, -1),
+  def decrypt(ciphertext, key, date = Date.today.strftime("%d%m%y"))
+    {decryption: mutate_string(ciphertext, key, date, -1),
      key: key,
      date: date}
   end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -16,12 +16,12 @@ class Enigma
     date_squared.to_s[-4..-1]
   end
 
-  def generate_shifts(key, date, dir)
+  def generate_shifts(key, date, direction)
     keys = {a: key[0..1], b: key[1..2], c: key[2..3], d: key[3..4]}
     offset = generate_offset(date)
     offsets = {a: offset[0], b: offset[1], c: offset[2], d: offset[3]}
     keys.merge(offsets) do |_, key_shift, offset_shift|
-      dir * (key_shift.to_i + offset_shift.to_i)
+      ((key_shift.to_i + offset_shift.to_i) * direction ) % 27
     end
   end
 
@@ -32,8 +32,8 @@ class Enigma
     return @charset.rotate(shifts[:d]) if index % 4 == 3
   end
 
-  def mutate_string(string, key, date, dir)
-    shifts = generate_shifts(key, date, dir)
+  def mutate_string(string, key, date, direction)
+    shifts = generate_shifts(key, date, direction)
     mutated_string = String.new
     string.each_char.with_index do |char, index|
       if @charset.include?(char)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,10 +1,10 @@
 require 'date'
 
 class Enigma
-  attr_reader :dictionary
+  attr_reader :charset
 
   def initialize
-    @dictionary = ("a".."z").to_a << " "
+    @charset = ("a".."z").to_a << " "
   end
 
   def generate_key
@@ -20,27 +20,29 @@ class Enigma
     keys = {a: key[0..1], b: key[1..2], c: key[2..3], d: key[3..4]}
     offset = generate_offset(date)
     offsets = {a: offset[0], b: offset[1], c: offset[2], d: offset[3]}
-    keys.merge(offsets) { |_, shift, offset| dir * (shift.to_i + offset.to_i) }
+    keys.merge(offsets) do |_, key_shift, offset_shift|
+      dir * (key_shift.to_i + offset_shift.to_i)
+    end
   end
 
-  def shifted_dictionary(index, shifts)
-    return @dictionary.rotate(shifts[:a]) if index % 4 == 0
-    return @dictionary.rotate(shifts[:b]) if index % 4 == 1
-    return @dictionary.rotate(shifts[:c]) if index % 4 == 2
-    return @dictionary.rotate(shifts[:d]) if index % 4 == 3
+  def shifted_charset(index, shifts)
+    return @charset.rotate(shifts[:a]) if index % 4 == 0
+    return @charset.rotate(shifts[:b]) if index % 4 == 1
+    return @charset.rotate(shifts[:c]) if index % 4 == 2
+    return @charset.rotate(shifts[:d]) if index % 4 == 3
   end
 
   def mutate_string(string, key, date, dir)
     shifts = generate_shifts(key, date, dir)
-    mutant = String.new
+    mutant_str = String.new
     string.each_char.with_index do |char, index|
-      if @dictionary.include?(char)
-        mutant += shifted_dictionary(index, shifts)[@dictionary.index(char)]
+      if @charset.include?(char)
+        mutant_str += shifted_charset(index, shifts)[@charset.index(char)]
       else
-        mutant += char
+        mutant_str += char
       end
     end
-    mutant
+    mutant_str
   end
 
   def encrypt(message, key = generate_key, date = Date.today.strftime("%d%m%y"))

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -51,7 +51,7 @@ class Enigma
      date: date}
   end
 
-  def decrypt(cipher, key, date)
+  def decrypt(cipher, key, date = Date.today.strftime("%d%m%y"))
     {decryption: mutate_string(cipher, key, date, -1),
      key: key,
      date: date}

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -25,7 +25,7 @@ class Enigma
     end
   end
 
-  def shifted_charset(index, shifts)
+  def shift_charset(index, shifts)
     return @charset.rotate(shifts[:a]) if index % 4 == 0
     return @charset.rotate(shifts[:b]) if index % 4 == 1
     return @charset.rotate(shifts[:c]) if index % 4 == 2
@@ -34,15 +34,15 @@ class Enigma
 
   def mutate_string(string, key, date, dir)
     shifts = generate_shifts(key, date, dir)
-    mutant_str = String.new
+    mutated_string = String.new
     string.each_char.with_index do |char, index|
       if @charset.include?(char)
-        mutant_str += shifted_charset(index, shifts)[@charset.index(char)]
+        mutated_string += shift_charset(index, shifts)[@charset.index(char)]
       else
-        mutant_str += char
+        mutated_string += char
       end
     end
-    mutant_str
+    mutated_string
   end
 
   def encrypt(message, key = generate_key, date = Date.today.strftime("%d%m%y"))

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -11,12 +11,12 @@ class EnigmaTest < Minitest::Test
   end
 
   def test_it_has_attributes
-    dictionary = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l",
+    charset = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l",
                   "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x",
                   "y", "z", " "]
 
 
-    assert_equal dictionary, @enigma.dictionary
+    assert_equal charset, @enigma.charset
   end
 
   def test_it_can_generate_a_key
@@ -44,7 +44,7 @@ class EnigmaTest < Minitest::Test
                 "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p",
                 "q", "r", "s"]
 
-    assert_equal expected, @enigma.shifted_dictionary(14, shifts)
+    assert_equal expected, @enigma.shifted_charset(14, shifts)
   end
 
   def test_it_can_mutate_a_string

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -49,12 +49,12 @@ class EnigmaTest < Minitest::Test
 
   def test_it_can_mutate_a_string
     message = "hello world"
-    cipher = "keder ohulw"
+    ciphertext = "keder ohulw"
     key = "02715"
     date = "040895"
 
-    assert_equal cipher, @enigma.mutate_string(message, key, date, +1)
-    assert_equal message, @enigma.mutate_string(cipher, key, date, -1)
+    assert_equal ciphertext, @enigma.mutate_string(message, key, date, +1)
+    assert_equal message, @enigma.mutate_string(ciphertext, key, date, -1)
   end
 
   def test_it_can_encrypt

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -44,7 +44,7 @@ class EnigmaTest < Minitest::Test
                 "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p",
                 "q", "r", "s"]
 
-    assert_equal expected, @enigma.shifted_charset(14, shifts)
+    assert_equal expected, @enigma.shift_charset(14, shifts)
   end
 
   def test_it_can_mutate_a_string

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -19,6 +19,11 @@ class EnigmaTest < Minitest::Test
     assert_equal charset, @enigma.charset
   end
 
+  def test_it_can_generate_today_date
+    Date.expects(:today).returns(Date.new(1995, 8, 4))
+    assert_equal "040895", @enigma.generate_today_date
+  end
+
   def test_it_can_generate_a_key
     @enigma.stubs(:rand).returns(923)
     assert_equal "00923", @enigma.generate_key
@@ -48,13 +53,13 @@ class EnigmaTest < Minitest::Test
   end
 
   def test_it_can_mutate_a_string
-    message = "hello world"
+    plaintext = "hello world"
     ciphertext = "keder ohulw"
     key = "02715"
     date = "040895"
 
-    assert_equal ciphertext, @enigma.mutate_string(message, key, date, +1)
-    assert_equal message, @enigma.mutate_string(ciphertext, key, date, -1)
+    assert_equal ciphertext, @enigma.mutate_string(plaintext, key, date, +1)
+    assert_equal plaintext, @enigma.mutate_string(ciphertext, key, date, -1)
   end
 
   def test_it_can_encrypt

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -29,16 +29,16 @@ class EnigmaTest < Minitest::Test
   end
 
   def test_it_can_generate_shifts
-    expected = {a: 3, b: 27, c: 73, d: 20}
+    expected = {a: 3, b: 0, c: 19, d: 20}
 
     assert_equal expected, @enigma.generate_shifts("02715", "040895", +1)
 
-    expected = {a: -3, b: -27, c: -73, d: -20}
+    expected = {a: 24, b: 0, c: 8, d: 7}
 
     assert_equal expected, @enigma.generate_shifts("02715", "040895", -1)
   end
 
-  def test_it_can_shift_the_dictionary
+  def test_it_can_shift_the_charset
     shifts = {a: 3, b: 27, c: 73, d: 20}
     expected = ["t", "u", "v", "w", "x", "y", "z", " ", "a", "b", "c", "d",
                 "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p",


### PR DESCRIPTION
Standardizes method and variable names to be more descriptive. Word changes include:
- "dictionary" -> "charset"
- "dir" -> "direction"
- "mutant" -> "mutated_string"
- "message" -> "plaintext"
- "cipher" -> "ciphertext"

`generate_shifts` now uses modulo 27 to reduce number of unnecessary full charset rotations in `shift_charset`. Tests updated to reflect word and behavior changes.

Adds method `generate_today_date` with test. This method is used in `Enigma#encrypt` and `Enigma#decrypt` and results in shorter def parameters in both methods. With these changes, CLI is ready to be implemented.