### PR TITLE
Cracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 runner.rb
 encrypted.txt
 decrypted.txt
+cracked.txt

--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@ Additionally, you will self assess your project before your evaluation. Make sur
 * [Evaluation Rubric](https://backend.turing.io/module1/projects/enigma/rubric)
 
 ## Self Assessment
-* Functionality:
-* Object Oriented Programming:
-* Ruby Conventions and Mechanics:
-* Test Driven Development:
-* Version Control:
+* **Functionality: 3** [cracking for a 4]
+  - Enigma Class with encrypt and decrypt  methods successfully implemented. Encrypt/decrypt command line interfaces successfully implemented.
+* **Object Oriented Programming: 3** [modules for a 4]
+  - Project is broken into logical components that are appropriately encapsulated. No classes are unreasonably small or large, or contain knowledge/information/behavior that they shouldn’t know about. Student can articulate the single responsibilities of the various components.
+* **Ruby Conventions and Mechanics: 4**
+  - Classes, methods, and variables are well named so that they clearly communicate their purpose. Code is all properly indented and syntax is consistent. No methods are longer than 10 lines long. Most enumerables/data structures chosen are the most efficient tool for a given job, and students can speak as to why those enumerables/data structures were chosen.
+* **Test Driven Development: 4**
+  - Mocks and/or stubs are used appropriately to ensure two or more of the following: testing is more robust (i.e., testing methods that might not otherwise be tested due to factors like randomness or user input), testing is more efficient, or that classes can be tested without relying on functionality from other classes. Students are able to speak as to how mocks and/or stubs are fulfilling the above conditions. Test coverage metrics show 100% coverage.
+* **Version Control: 4**
+  - At least 40 commits. All pull requests include related and logical chunks of functionality, and are named and documented to clearly communicate the purpose of the pull request. No commits include multiple pieces of functionality. No commit message is ambiguous.

--- a/lib/crack.rb
+++ b/lib/crack.rb
@@ -1,0 +1,13 @@
+require './lib/enigma'
+
+encrypted = File.open(ARGV[0], "r")
+ciphertext = encrypted.read
+
+enigma = Enigma.new
+decryption_data = enigma.crack(ciphertext, ARGV[2])
+
+cracked = File.open(ARGV[1], "w")
+cracked.write(decryption_data[:decryption])
+cracked.close
+
+p "Created '#{ARGV[1]}' with the cracked key #{decryption_data[:key]} and date #{decryption_data[:date]}"

--- a/lib/decrypt.rb
+++ b/lib/decrypt.rb
@@ -2,11 +2,11 @@ require './lib/enigma'
 
 encrypted = File.open(ARGV[0], "r")
 ciphertext = encrypted.read
-decrypted = File.open(ARGV[1], "w")
 
 enigma = Enigma.new
-
 decryption_data = enigma.decrypt(ciphertext, ARGV[2], ARGV[3])
+
+decrypted = File.open(ARGV[1], "w")
 decrypted.write(decryption_data[:decryption])
 decrypted.close
 

--- a/lib/encrypt.rb
+++ b/lib/encrypt.rb
@@ -2,11 +2,11 @@ require './lib/enigma'
 
 message = File.open(ARGV[0], "r")
 plaintext = message.read
-encrypted = File.open(ARGV[1], "w")
 
 enigma = Enigma.new
-
 encryption_data = enigma.encrypt(plaintext, ARGV[2], ARGV[3])
+
+encrypted = File.open(ARGV[1], "w")
 encrypted.write(encryption_data[:encryption])
 encrypted.close
 

--- a/lib/encrypt.rb
+++ b/lib/encrypt.rb
@@ -4,7 +4,7 @@ message = File.open(ARGV[0], "r")
 plaintext = message.read
 
 enigma = Enigma.new
-encryption_data = enigma.encrypt(plaintext, ARGV[2], ARGV[3])
+encryption_data = enigma.encrypt(plaintext)
 
 encrypted = File.open(ARGV[1], "w")
 encrypted.write(encryption_data[:encryption])

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -81,16 +81,15 @@ class Enigma
     cracked_primary_keys.values
   end
 
-  def keys_pattern?(keys)
+  def primary_keys_pattern?(keys)
     keys[0][1] == keys[1][0] && keys[1][1] == keys[2][0] &&
     keys[2][1] == keys[3][0]
   end
 
   def crack_key(date, shifts)
-    keys = crack_keys(date, shifts)
-    require 'pry'; binding.pry
+    keys = calculate_primary_keys(date, shifts)
     keys.each.with_index do |key, index|
-      break if keys_pattern?(keys)
+      break if primary_keys_pattern?(keys)
       until keys[index][1] == keys[index + 1][0]
         keys[index + 1] = (keys[index + 1].to_i + 27).to_s.rjust(2, "0")
       end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -88,17 +88,22 @@ class Enigma
     cracked_keys.values
   end
 
-  def keys_pattern?(key)
-    key[0][1] == key[1][0] && key[1][1] == key[2][0] && key[2][1] == key[3][0]
-  end
+  # def keys_pattern?(key)
+  #   key[0][1] == key[1][0] && key[1][1] == key[2][0] && key[2][1] == key[3][0]
+  # end
 
-  def normalize_keys(cracked_keys)
+  def crack_key(keys)
     # develop key matching pairing pattern
-    until keys_pattern? do
-      key[0].to_i
-      key[1].to_i
-      key[2].to_i
-      key[3].to_i
+    until keys[0][1] == keys[1][0]
+      keys[1] = (keys[1].to_i + 27).to_s.rjust(2, "0")
     end
+    until keys[1][1] == keys[2][0]
+      keys[2] = (keys[2].to_i + 27).to_s.rjust(2, "0")
+    end
+    until keys[2][1] == keys[3][0]
+      keys[3] = (keys[3].to_i + 27).to_s.rjust(2, "0")
+    end
+    keys[0] + keys[1][1] + keys[2][1] + keys[3][1]
+    # {a: keys[0].to_i, b: keys[1].to_i, c: keys[2].to_i, d: keys[3].to_i}
   end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -88,18 +88,17 @@ class Enigma
     cracked_keys.values
   end
 
+  def keys_pattern?(key)
+    key[0][1] == key[1][0] && key[1][1] == key[2][0] && key[2][1] == key[3][0]
+  end
+
   def normalize_keys(cracked_keys)
     # develop key matching pairing pattern
-    require 'pry'; binding.pry
-
-
-    # prelim_keys = prelim_keys.values
-    # keys_string = cracked_keys.map { |key| key.to_s.rjust(2, "0") }
-    #
-    # prelim_keys = positive_keys.transform_values do |key|
-    #   key.to_s.rjust(2, "0")
-    # end
-    #
-    # require 'pry'; binding.pry
+    until keys_pattern? do
+      key[0].to_i
+      key[1].to_i
+      key[2].to_i
+      key[3].to_i
+    end
   end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -87,6 +87,7 @@ class Enigma
   def crack_key(date, shifts)
     keys = calculate_primary_keys(date, shifts)
     keys.each.with_index do |key, index|
+      require 'pry'; binding.pry
       break if primary_keys_pattern?(keys)
       until (keys[index][1] == keys[index + 1][0])
         keys[index + 1] = (keys[index + 1].to_i + 27).to_s.rjust(2, "0")

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -15,15 +15,15 @@ class Enigma
     rand(99999).to_s.rjust(5, "0")
   end
 
-  def generate_offset(date)
+  def generate_offsets(date)
     date_squared = date.to_i**2
-    date_squared.to_s[-4..-1]
+    offset = date_squared.to_s[-4..-1]
+    {a: offset[0], b: offset[1], c: offset[2], d: offset[3]}
   end
 
   def generate_shifts(key, date, direction)
     keys = {a: key[0..1], b: key[1..2], c: key[2..3], d: key[3..4]}
-    offset = generate_offset(date)
-    offsets = {a: offset[0], b: offset[1], c: offset[2], d: offset[3]}
+    offsets = generate_offsets(date)
     keys.merge(offsets) do |_, key_shift, offset_shift|
       ((key_shift.to_i + offset_shift.to_i) * direction ) % 27
     end
@@ -36,8 +36,7 @@ class Enigma
     return @charset.rotate(shifts[:d]) if index % 4 == 3
   end
 
-  def mutate_string(string, key, date, direction)
-    shifts = generate_shifts(key, date, direction)
+  def mutate_string(string, shifts)
     mutated_string = String.new
     string.each_char.with_index do |char, index|
       if @charset.include?(char)
@@ -52,48 +51,42 @@ class Enigma
   def encrypt(plaintext, key = generate_key, date = generate_today_date)
     key = generate_key if key == nil
     date = generate_today_date if date  == nil
-    {encryption: mutate_string(plaintext.downcase, key, date, +1),
+    shifts = generate_shifts(key, date, +1)
+    {encryption: mutate_string(plaintext.downcase, shifts),
      key: key,
      date: date}
   end
 
   def decrypt(ciphertext, key, date = generate_today_date)
-    {decryption: mutate_string(ciphertext, key, date, -1),
+    shifts = generate_shifts(key, date, -1)
+    {decryption: mutate_string(ciphertext, shifts),
      key: key,
      date: date}
   end
 
   def crack(ciphertext, date = generate_today_date)
-    # shif ["x", "x", "x", "x"] length 4 => d_char_modulus 0
-    # orig [" ", "e", "n", "d"]
-    # indx [ -4,  -3,  -2,  -1]
-    d_shift = @charset.index(ciphertext[-1]) - 3
-    n_shift = @charset.index(ciphertext[-2]) - 13
-    e_shift = @charset.index(ciphertext[-3]) - 4
-    space_shift = @charset.index(ciphertext[-3]) - 27
+    offsets = generate_offsets(date)
+    shifts = crack_shifts(ciphertext)
+    {decryption: mutate_string(ciphertext, shifts),
+     key: key_generator(date, shifts),
+     date: date}
+  end
+
+  def crack_shifts(ciphertext)
+    d_shift = 3 - @charset.index(ciphertext[-1])
+    n_shift = 13 - @charset.index(ciphertext[-2])
+    e_shift = 4 - @charset.index(ciphertext[-3])
+    space_shift = 26 - @charset.index(ciphertext[-4])
     shift_values = [space_shift, e_shift, n_shift, d_shift]
     shift_keys = [:a, :b, :c, :d]
-    if ciphertext.length % 4  == 0
-      shifts = shift_keys.zip(shift_values).to_h
-      # shift_d = d_shift
-      # shift_c = n_shift
-      # shift_b = e_shift
-      # shift_a = space_shift
-    elsif last_index % 4 == 1
-      shifts = shift_keys.zip(shift_values.rotate).to_h
-      # shift_a = d_shift
-      # shift_d = n_shift
-      # shift_c = e_shift
-      # shift_b = space_shift
-    elsif last_index % 4 == 2
-      # shift_b = d_shift
-      # shift_a = n_shift
-      # shift_d = e_shift
-      # shift_c = space_shift
-    elsif last_index % 4 == 2
-      # shift_c = d_shift
-      # shift_b = n_shift
-      # shift_a = e_shift
-      # shift_d = space_shift
+    index_positions = ciphertext.length - 1
+    rotations = ciphertext.length
+    shift_keys.zip(shift_values.rotate(rotations)).to_h
+  end
+
+  def key_generator(date, shifts)
+    shifts = shifts.merge(offsets) do |_, shift, offset|
+      shift.to_i - offset.to_i
+    end
   end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -49,8 +49,6 @@ class Enigma
   end
 
   def encrypt(plaintext, key = generate_key, date = generate_today_date)
-    key = generate_key if key == nil
-    date = generate_today_date if date  == nil
     shifts = generate_shifts(key, date, +1)
     {encryption: mutate_string(plaintext.downcase, shifts),
      key: key,

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -62,4 +62,38 @@ class Enigma
      key: key,
      date: date}
   end
+
+  def crack(ciphertext, date = generate_today_date)
+    # shif ["x", "x", "x", "x"] length 4 => d_char_modulus 0
+    # orig [" ", "e", "n", "d"]
+    # indx [ -4,  -3,  -2,  -1]
+    d_shift = @charset.index(ciphertext[-1]) - 3
+    n_shift = @charset.index(ciphertext[-2]) - 13
+    e_shift = @charset.index(ciphertext[-3]) - 4
+    space_shift = @charset.index(ciphertext[-3]) - 27
+    shift_values = [space_shift, e_shift, n_shift, d_shift]
+    shift_keys = [:a, :b, :c, :d]
+    if ciphertext.length % 4  == 0
+      shifts = shift_keys.zip(shift_values).to_h
+      # shift_d = d_shift
+      # shift_c = n_shift
+      # shift_b = e_shift
+      # shift_a = space_shift
+    elsif last_index % 4 == 1
+      shifts = shift_keys.zip(shift_values.rotate).to_h
+      # shift_a = d_shift
+      # shift_d = n_shift
+      # shift_c = e_shift
+      # shift_b = space_shift
+    elsif last_index % 4 == 2
+      # shift_b = d_shift
+      # shift_a = n_shift
+      # shift_d = e_shift
+      # shift_c = space_shift
+    elsif last_index % 4 == 2
+      # shift_c = d_shift
+      # shift_b = n_shift
+      # shift_a = e_shift
+      # shift_d = space_shift
+  end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -25,7 +25,7 @@ class Enigma
     keys = {a: key[0..1], b: key[1..2], c: key[2..3], d: key[3..4]}
     offsets = generate_offsets(date)
     keys.merge(offsets) do |_, key_shift, offset_shift|
-      ((key_shift.to_i + offset_shift.to_i) * direction ) % 27
+      (key_shift.to_i + offset_shift.to_i) * direction
     end
   end
 
@@ -65,28 +65,41 @@ class Enigma
   end
 
   def crack(ciphertext, date = generate_today_date)
-    offsets = generate_offsets(date)
     shifts = crack_shifts(ciphertext)
     {decryption: mutate_string(ciphertext, shifts),
-     key: key_generator(date, shifts),
-     date: date}
+     date: date,
+     key: key_generator(date, shifts)}
   end
 
   def crack_shifts(ciphertext)
-    d_shift = 3 - @charset.index(ciphertext[-1])
-    n_shift = 13 - @charset.index(ciphertext[-2])
-    e_shift = 4 - @charset.index(ciphertext[-3])
-    space_shift = 26 - @charset.index(ciphertext[-4])
+    d_shift = (@charset.index(ciphertext[-1]) - 3) % 27
+    n_shift = (@charset.index(ciphertext[-2]) - 13) % 27
+    e_shift = (@charset.index(ciphertext[-3]) - 4) % 27
+    space_shift = (@charset.index(ciphertext[-4]) - 26) % 27
     shift_values = [space_shift, e_shift, n_shift, d_shift]
-    shift_keys = [:a, :b, :c, :d]
-    index_positions = ciphertext.length - 1
-    rotations = ciphertext.length
-    shift_keys.zip(shift_values.rotate(rotations)).to_h
+    [:a, :b, :c, :d].zip(shift_values.rotate(ciphertext.length % 4)).to_h
   end
 
-  def key_generator(date, shifts)
-    shifts = shifts.merge(offsets) do |_, shift, offset|
-      shift.to_i - offset.to_i
+  def crack_keys(date, shifts)
+    offsets = generate_offsets(date)
+    cracked_keys = shifts.merge(offsets) do |_, shift, offset_shift|
+      ((shift - offset_shift.to_i) % 27).to_s.rjust(2, "0")
     end
+    cracked_keys.values
+  end
+
+  def normalize_keys(cracked_keys)
+    # develop key matching pairing pattern
+    require 'pry'; binding.pry
+
+
+    # prelim_keys = prelim_keys.values
+    # keys_string = cracked_keys.map { |key| key.to_s.rjust(2, "0") }
+    #
+    # prelim_keys = positive_keys.transform_values do |key|
+    #   key.to_s.rjust(2, "0")
+    # end
+    #
+    # require 'pry'; binding.pry
   end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -90,7 +90,7 @@ class Enigma
     keys = calculate_primary_keys(date, shifts)
     keys.each.with_index do |key, index|
       break if primary_keys_pattern?(keys)
-      until keys[index][1] == keys[index + 1][0]
+      until (keys[index][1] == keys[index + 1][0])
         keys[index + 1] = (keys[index + 1].to_i + 27).to_s.rjust(2, "0")
       end
     end
@@ -103,5 +103,4 @@ class Enigma
      date: date,
      key: crack_key(date, shifts)}
   end
-
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -87,7 +87,6 @@ class Enigma
   def crack_key(date, shifts)
     keys = calculate_primary_keys(date, shifts)
     keys.each.with_index do |key, index|
-      require 'pry'; binding.pry
       break if primary_keys_pattern?(keys)
       until (keys[index][1] == keys[index + 1][0])
         keys[index + 1] = (keys[index + 1].to_i + 27).to_s.rjust(2, "0")

--- a/message.txt
+++ b/message.txt
@@ -25,4 +25,4 @@ in cracking the Enigma code – was kept secret until the 1970s, and the full
 story was not known until the 1990s. It has been estimated that the efforts of
 Turing and his fellow code-breakers shortened the war by several years. What is
 certain is that they saved countless lives and helped to determine the course
-and outcome of the conflict.
+and outcome of the conflict. end

--- a/runner.rb
+++ b/runner.rb
@@ -2,4 +2,16 @@ require './lib/enigma'
 
 enigma = Enigma.new
 
+message = " end"
+encrypted = enigma.encrypt(message, "08035", "020320")
+actual_shifts = enigma.generate_shifts("08035", "020320", +1)
+cracked_shifts = enigma.crack_shifts(encrypted[:encryption])
+offsets = enigma.generate_offsets("020320")
+actual_keys = actual_shifts.merge(offsets)do |_, shift, offset_shift|
+  (shift - offset_shift.to_i).to_s.rjust(2, "0")
+end
+
+preliminary_keys = cracked_shifts.merge(offsets) do |_, shift, offset_shift|
+  ((shift - offset_shift.to_i) % 27).to_s.rjust(2, "0")
+end
 require 'pry'; binding.pry

--- a/runner.rb
+++ b/runner.rb
@@ -1,17 +1,4 @@
 require './lib/enigma'
 
 enigma = Enigma.new
-
-message = " end"
-encrypted = enigma.encrypt(message, "08035", "020320")
-actual_shifts = enigma.generate_shifts("08035", "020320", +1)
-cracked_shifts = enigma.crack_shifts(encrypted[:encryption])
-offsets = enigma.generate_offsets("020320")
-actual_keys = actual_shifts.merge(offsets)do |_, shift, offset_shift|
-  (shift - offset_shift.to_i).to_s.rjust(2, "0")
-end
-
-preliminary_keys = cracked_shifts.merge(offsets) do |_, shift, offset_shift|
-  ((shift - offset_shift.to_i) % 27).to_s.rjust(2, "0")
-end
 require 'pry'; binding.pry

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -88,18 +88,19 @@ class EnigmaTest < Minitest::Test
   end
 
   def test_it_can_crack_shifts
-    assert_equal ({a: 10, b: 3, c: 3, d: 8}), @enigma.crack_shifts("jhql")
+    ciphertext = "vjqtbeaweqihssi"
+    expected = {a: 13, b: 22, c: 22, d: 19}
+    assert_equal expected, @enigma.crack_shifts(ciphertext)
   end
 
-  def test_it_can_crack_keys
-    shifts = @enigma.crack_shifts("jhql")
-    expected = ["08", "26", "03", "08"]
+  def test_it_can_calculate_primary_keys
+    shifts = @enigma.crack_shifts("vjqtbeaweqihssi")
+    expected = ["08", "02", "03", "04"]
 
-    assert_equal expected, @enigma.crack_keys("020320",shifts)
+    assert_equal expected, @enigma.calculate_primary_keys("291018",shifts)
   end
 
   def test_it_can_check_keys_against_pattern
-    skip
     key1 = ["08", "80", "03", "35"]
     key2 = ["03", "04", "03", "25"]
 
@@ -107,13 +108,13 @@ class EnigmaTest < Minitest::Test
     assert_equal false, @enigma.keys_pattern?(key2)
   end
 
-  def test_it_can_crack_key
+  def test_it_can_generate_key
+    skip
     shifts = @enigma.crack_shifts("jhql")
-    cracked_keys = @enigma.crack_keys("020320",shifts)
 
     expected = "08035"
 
-    assert_equal expected, @enigma.crack_key(cracked_keys)
+    assert_equal expected, @enigma.crack_key("020320",shifts)
   end
 
   def test_it_can_crack

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -90,31 +90,32 @@ class EnigmaTest < Minitest::Test
   def test_it_can_crack_shifts
     ciphertext = "vjqtbeaweqihssi"
     expected = {a: 13, b: 22, c: 22, d: 19}
+
     assert_equal expected, @enigma.crack_shifts(ciphertext)
   end
 
   def test_it_can_calculate_primary_keys
+    date = "291018"
     shifts = @enigma.crack_shifts("vjqtbeaweqihssi")
     expected = ["08", "02", "03", "04"]
 
-    assert_equal expected, @enigma.calculate_primary_keys("291018",shifts)
+    assert_equal expected, @enigma.calculate_primary_keys(date ,shifts)
   end
 
-  def test_it_can_check_keys_against_pattern
+  def test_it_can_check_keys_against_key_pattern
     key1 = ["08", "80", "03", "35"]
     key2 = ["03", "04", "03", "25"]
 
-    assert_equal true, @enigma.keys_pattern?(key1)
-    assert_equal false, @enigma.keys_pattern?(key2)
+    assert_equal true, @enigma.primary_keys_pattern?(key1)
+    assert_equal false, @enigma.primary_keys_pattern?(key2)
   end
 
-  def test_it_can_generate_key
-    skip
-    shifts = @enigma.crack_shifts("jhql")
+  def test_it_can_generate_cracked_key
+    shifts = @enigma.crack_shifts("vjqtbeaweqihssi")
 
-    expected = "08035"
+    expected = "08304"
 
-    assert_equal expected, @enigma.crack_key("020320",shifts)
+    assert_equal expected, @enigma.crack_key("291018", shifts)
   end
 
   def test_it_can_crack

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -99,6 +99,7 @@ class EnigmaTest < Minitest::Test
   end
 
   def test_it_can_check_keys_against_pattern
+    skip
     key1 = ["08", "80", "03", "35"]
     key2 = ["03", "04", "03", "25"]
 
@@ -106,16 +107,14 @@ class EnigmaTest < Minitest::Test
     assert_equal false, @enigma.keys_pattern?(key2)
   end
 
-  def test_it_can_normalize_keys
-    skip
+  def test_it_can_crack_key
     shifts = @enigma.crack_shifts("jhql")
     cracked_keys = @enigma.crack_keys("020320",shifts)
 
-    expected = {a: 8, b: 80, c: 3, d: 35}
+    expected = "08035"
 
-    assert_equal expected, @enigma.normalize_keys(cracked_keys)
+    assert_equal expected, @enigma.crack_key(cracked_keys)
   end
-
 
   def test_it_can_crack
     skip

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -112,7 +112,6 @@ class EnigmaTest < Minitest::Test
 
   def test_it_can_generate_cracked_key
     shifts = @enigma.crack_shifts("vjqtbeaweqihssi")
-
     expected = "08304"
 
     assert_equal expected, @enigma.crack_key("291018", shifts)

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -119,7 +119,6 @@ class EnigmaTest < Minitest::Test
   end
 
   def test_it_can_crack
-    skip
     expected = {decryption: "hello world end",
                 date: "291018",
                 key: "08304"}

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -83,4 +83,15 @@ class EnigmaTest < Minitest::Test
 
     assert_equal expected, @enigma.decrypt("keder ohulw", "02715", "040895")
   end
+
+  def test_it_can_crack
+    expected = {decryption: "hello world",
+                key: "???",
+                date: "291018"}
+
+    assert_equal expected, @enigma.crack("vjqtbeaweqihssi", "291018")
+
+    Date.expects(:today).returns(Date.new(2018, 10, 29))
+    assert_equal expected, @enigma.crack("vjqtbeaweqihssi")
+  end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -98,6 +98,14 @@ class EnigmaTest < Minitest::Test
     assert_equal expected, @enigma.crack_keys("020320",shifts)
   end
 
+  def test_it_can_check_keys_against_pattern
+    key1 = ["08", "80", "03", "35"]
+    key2 = ["03", "04", "03", "25"]
+
+    assert_equal true, @enigma.keys_pattern?(key1)
+    assert_equal false, @enigma.keys_pattern?(key2)
+  end
+
   def test_it_can_normalize_keys
     skip
     shifts = @enigma.crack_shifts("jhql")
@@ -107,6 +115,7 @@ class EnigmaTest < Minitest::Test
 
     assert_equal expected, @enigma.normalize_keys(cracked_keys)
   end
+
 
   def test_it_can_crack
     skip

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -28,8 +28,8 @@ class EnigmaTest < Minitest::Test
     assert_equal "00923", @enigma.generate_key
   end
 
-  def test_it_can_generate_an_offset
-    assert_equal "1025", @enigma.generate_offset("040895")
+  def test_it_can_generate_offsets
+    assert_equal ({a: "1", b: "0", c: "2", d: "5"}), @enigma.generate_offsets("040895")
   end
 
   def test_it_can_generate_shifts
@@ -57,8 +57,11 @@ class EnigmaTest < Minitest::Test
     key = "02715"
     date = "040895"
 
-    assert_equal ciphertext, @enigma.mutate_string(plaintext, key, date, +1)
-    assert_equal plaintext, @enigma.mutate_string(ciphertext, key, date, -1)
+    shifts = @enigma.generate_shifts(key, date, +1)
+    assert_equal ciphertext, @enigma.mutate_string(plaintext, shifts)
+
+    shifts = @enigma.generate_shifts(key, date, -1)
+    assert_equal plaintext, @enigma.mutate_string(ciphertext, shifts)
   end
 
   def test_it_can_encrypt
@@ -84,10 +87,15 @@ class EnigmaTest < Minitest::Test
     assert_equal expected, @enigma.decrypt("keder ohulw", "02715", "040895")
   end
 
+  def test_it_can_crack_shifts
+    assert_equal ({a: 19, b: -14, c: -11, d: -7}), @enigma.crack_shifts("hsyk")
+  end
+
   def test_it_can_crack
-    expected = {decryption: "hello world",
-                key: "???",
-                date: "291018"}
+    skip
+    expected = {decryption: "hello world end",
+                date: "291018",
+                key: "08304"}
 
     assert_equal expected, @enigma.crack("vjqtbeaweqihssi", "291018")
 

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -33,11 +33,11 @@ class EnigmaTest < Minitest::Test
   end
 
   def test_it_can_generate_shifts
-    expected = {a: 3, b: 0, c: 19, d: 20}
+    expected = {a: 3, b: 27, c: 73, d: 20}
 
     assert_equal expected, @enigma.generate_shifts("02715", "040895", +1)
 
-    expected = {a: 24, b: 0, c: 8, d: 7}
+    expected = {a: -3, b: -27, c: -73, d: -20}
 
     assert_equal expected, @enigma.generate_shifts("02715", "040895", -1)
   end
@@ -88,7 +88,21 @@ class EnigmaTest < Minitest::Test
   end
 
   def test_it_can_crack_shifts
-    assert_equal ({a: 19, b: -14, c: -11, d: -7}), @enigma.crack_shifts("hsyk")
+    assert_equal ({a: 10, b: 3, c: 3, d: 8}), @enigma.crack_shifts("jhql")
+  end
+
+  def test_it_can_crack_keys
+    shifts = @enigma.crack_shifts("jhql")
+    expected = {a: 8, b: -1, c: 3, d: 8}
+
+    assert_equal expected, @enigma.crack_keys("020320",shifts)
+  end
+
+  def test_it_can_normalize_keys
+    expected = {a: 8, b: 80, c: 3, d: 35}
+    cracked_keys = @enigma.crack_keys("020320",shifts)
+
+    assert_equal expected, @enigma.normalize_keys(cracked_keys)
   end
 
   def test_it_can_crack

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -93,14 +93,17 @@ class EnigmaTest < Minitest::Test
 
   def test_it_can_crack_keys
     shifts = @enigma.crack_shifts("jhql")
-    expected = {a: 8, b: -1, c: 3, d: 8}
+    expected = ["08", "26", "03", "08"]
 
     assert_equal expected, @enigma.crack_keys("020320",shifts)
   end
 
   def test_it_can_normalize_keys
-    expected = {a: 8, b: 80, c: 3, d: 35}
+    skip
+    shifts = @enigma.crack_shifts("jhql")
     cracked_keys = @enigma.crack_keys("020320",shifts)
+
+    expected = {a: 8, b: 80, c: 3, d: 35}
 
     assert_equal expected, @enigma.normalize_keys(cracked_keys)
   end


### PR DESCRIPTION
Adds complete cracking functionality, including CLI for reading and writing files.  Removes ability to specify key/date when encrypting via CLI. Also include self assessment. Other changes include:
* `Enigma#generate_offset(s)` returns a hash of all offset subsets
* Remove modulo on sum of key shifts and offset shifts (keeps raw shift for processing later with specialized methods)
* `Enigma#mutate_string` now receives shifts as a parameter instead of generating shifts in the method. This permits forking responsibilities for `Enigma#crack`
*  Remove newline on messages.txt and append add " end" to enable cracking.